### PR TITLE
Merge upstream 2.02-coreos branch 2019-10-24

### DIFF
--- a/grub-core/efiemu/i386/loadcore64.c
+++ b/grub-core/efiemu/i386/loadcore64.c
@@ -98,6 +98,7 @@ grub_arch_efiemu_relocate_symbols64 (grub_efiemu_segment_t segs,
 		    break;
 
 		  case R_X86_64_PC32:
+		  case R_X86_64_PLT32:
 		    err = grub_efiemu_write_value (addr,
 						   *addr32 + rel->r_addend
 						   + sym.off

--- a/grub-core/fs/btrfs.c
+++ b/grub-core/fs/btrfs.c
@@ -175,7 +175,7 @@ struct grub_btrfs_time
 {
   grub_int64_t sec;
   grub_uint32_t nanosec;
-} __attribute__ ((aligned (4)));
+} GRUB_PACKED;
 
 struct grub_btrfs_inode
 {

--- a/grub-core/kern/x86_64/dl.c
+++ b/grub-core/kern/x86_64/dl.c
@@ -70,6 +70,7 @@ grub_arch_dl_relocate_symbols (grub_dl_t mod, void *ehdr,
 	  break;
 
 	case R_X86_64_PC32:
+	case R_X86_64_PLT32:
 	  {
 	    grub_int64_t value;
 	    value = ((grub_int32_t) *addr32) + rel->r_addend + sym->st_value -

--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -826,7 +826,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 
   len = sizeof (linux_params) - sizeof (lh);
 
-  grub_memcpy (&linux_params + sizeof (lh), kernel + kernel_offset, len);
+  grub_memcpy ((char *) &linux_params + sizeof (lh), kernel + kernel_offset, len);
   kernel_offset += len;
 
   linux_params.type_of_loader = GRUB_LINUX_BOOT_LOADER_TYPE;

--- a/include/grub/efiemu/runtime.h
+++ b/include/grub/efiemu/runtime.h
@@ -29,7 +29,7 @@ struct grub_efiemu_ptv_rel
 
 struct efi_variable
 {
-  grub_efi_guid_t guid;
+  grub_efi_packed_guid_t guid;
   grub_uint32_t namelen;
   grub_uint32_t size;
   grub_efi_uint32_t attributes;

--- a/include/grub/gpt_partition.h
+++ b/include/grub/gpt_partition.h
@@ -29,7 +29,7 @@ struct grub_gpt_guid
   grub_uint16_t data2;
   grub_uint16_t data3;
   grub_uint8_t data4[8];
-} __attribute__ ((aligned(8)));
+} GRUB_PACKED;
 typedef struct grub_gpt_guid grub_gpt_guid_t;
 typedef struct grub_gpt_guid grub_gpt_part_type_t;
 

--- a/util/grub-mkimagexx.c
+++ b/util/grub-mkimagexx.c
@@ -832,6 +832,7 @@ SUFFIX (relocate_addresses) (Elf_Ehdr *e, Elf_Shdr *sections,
 		  break;
 
 		case R_X86_64_PC32:
+		case R_X86_64_PLT32:
 		  {
 		    grub_uint32_t *t32 = (grub_uint32_t *) target;
 		    *t32 = grub_host_to_target64 (grub_target_to_host32 (*t32)

--- a/util/grub-module-verifier.c
+++ b/util/grub-module-verifier.c
@@ -19,6 +19,7 @@ struct grub_module_verifier_arch archs[] = {
       -1
     }, (int[]){
       R_X86_64_PC32,
+      R_X86_64_PLT32,
       -1
     }
   },


### PR DESCRIPTION
So far `CROS_WORKON_COMMIT` in `coreos-overlay/sys-grub/grub*.ebuild` pointed to the top of `2.02-coreos` branch. On the other hand, `flatcar-master` branch stayed a little behind, without having several patches. That has worked well so far, as we have followed the unusual workflow with no change.

Now that we started Edge releases based on diff from any build branch to flatcar-master, it ended up writing a backward change to each `build-xxxx.99.*` branch. As a result, we have seen occasional failures when running `grub-mkimage`.

Let's simply merge the recent bug fixes from `2.02-coreos` branch to `flatcar-master`. That way we will not have to deal with another special cases of different base branch names.


