### PR TITLE
tsc: Change default tsc calibration method to pmtimer on EFI systems

### DIFF
--- a/grub-core/kern/i386/tsc.c
+++ b/grub-core/kern/i386/tsc.c
@@ -68,7 +68,7 @@ grub_tsc_init (void)
 #ifdef GRUB_MACHINE_XEN
   (void) (grub_tsc_calibrate_from_xen () || calibrate_tsc_hardcode());
 #elif defined (GRUB_MACHINE_EFI)
-  (void) (grub_tsc_calibrate_from_pit () || grub_tsc_calibrate_from_pmtimer () || grub_tsc_calibrate_from_efi() || calibrate_tsc_hardcode());
+  (void) (grub_tsc_calibrate_from_pmtimer () || grub_tsc_calibrate_from_pit () || grub_tsc_calibrate_from_efi() || calibrate_tsc_hardcode());
 #elif defined (GRUB_MACHINE_COREBOOT)
   (void) (grub_tsc_calibrate_from_pmtimer () || grub_tsc_calibrate_from_pit () || calibrate_tsc_hardcode());
 #else


### PR DESCRIPTION
Current grub in Flatcar hangs on Fujitsu PRIMERGY RX1330 M5 servers. This cherry-pick fixes it.